### PR TITLE
Fixed crash when passing an empty connect string with no window handle

### DIFF
--- a/iodbcadm/drvconn.c
+++ b/iodbcadm/drvconn.c
@@ -271,6 +271,10 @@ iodbcdm_drvconn_dialboxw (
 
   if (!szDSN && !szDriver)
     {
+      /* Initialize members in case of early create_dsnchooser return */
+      choose_t.dsn = NULL;
+      choose_t.fdsn = NULL;
+
       /* Display the DSN chooser dialog box */
       create_dsnchooser (hwnd, &choose_t);
 


### PR DESCRIPTION
This fixes the iodbctest crash when you pass an invalid connection string (eg. "=").