### PR TITLE
OS X: Fixed crash when create_dsnsetup fails to load the window

### DIFF
--- a/drvproxy/macosx/gensetup.c
+++ b/drvproxy/macosx/gensetup.c
@@ -698,5 +698,5 @@ LPSTR create_gensetup (HWND hwnd, LPCSTR dsn,
 
 error:
   fprintf (stderr, "Can't load Window. Err: %d\n", (int) err);
-  return gensetup_t.connstr;
+  return NULL;
 }


### PR DESCRIPTION
The returned value was uninitialized and was attempted to be freed in ConfigDSN.

Fixes the crash and config corruption parts of #9.