### PR TITLE
Fixed iODBCdrvproxy XIBs not compiling to NIBs on OS X

### DIFF
--- a/mac/iODBCdrvproxy/iODBCdrvproxy.xcodeproj/project.pbxproj
+++ b/mac/iODBCdrvproxy/iODBCdrvproxy.xcodeproj/project.pbxproj
@@ -80,11 +80,11 @@
 /* End PBXBuildStyle section */
 
 /* Begin PBXFileReference section */
-		0145C11EFFD6607A7F000001 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = English; path = English.lproj/gensetup.xib; sourceTree = "<group>"; };
+		0145C11EFFD6607A7F000001 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xib; name = English; path = English.lproj/gensetup.xib; sourceTree = "<group>"; };
 		089C167EFE841241C02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0A7B5B2F005FB5307F000001 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
 		0A7B5B30005FB5307F000001 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = /System/Library/Frameworks/Carbon.framework; sourceTree = "<absolute>"; };
-		10DCE823FFD6A5D57F000001 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = English; path = English.lproj/login.xib; sourceTree = "<group>"; };
+		10DCE823FFD6A5D57F000001 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xib; name = English; path = English.lproj/login.xib; sourceTree = "<group>"; };
 		1C1241FC005FB6B37F000001 /* ConfigDriver.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ConfigDriver.c; sourceTree = "<group>"; };
 		1C1241FD005FB6B37F000001 /* ConfigDSN.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ConfigDSN.c; sourceTree = "<group>"; };
 		1C1241FE005FB6B37F000001 /* drvconn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = drvconn.c; sourceTree = "<group>"; };
@@ -103,7 +103,7 @@
 		71A26EE1069D5691005AC343 /* iodbcext.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = iodbcext.h; path = ../../include/iodbcext.h; sourceTree = SOURCE_ROOT; };
 		71A26EE2069D5691005AC343 /* iodbcunix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = iodbcunix.h; path = ../../include/iodbcunix.h; sourceTree = SOURCE_ROOT; };
 		859838AB07CF6D6D0022E958 /* confirm.c */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.c; path = confirm.c; sourceTree = "<group>"; };
-		859843D807D356DA0022E958 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = English; path = English.lproj/confirmation.xib; sourceTree = "<group>"; };
+		859843D807D356DA0022E958 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xib; name = English; path = English.lproj/confirmation.xib; sourceTree = "<group>"; };
 		85D1BB9807E7D55A0070A59E /* iODBCinst.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iODBCinst.framework; path = ../../mac/iODBCinst/build/iODBCinst.framework; sourceTree = SOURCE_ROOT; };
 		CDAE3BCB0987D6B4003250F8 /* Info-iODBCdrvproxy.plist */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Info-iODBCdrvproxy.plist"; sourceTree = "<group>"; };
 		CDAE3BCC0987D6B4003250F8 /* iODBCdrvproxy.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iODBCdrvproxy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };


### PR DESCRIPTION
This causes certain windows to not load at all.

Fixes the window not loading part of #9.