### PR TITLE
non-void function needs to return a value

### DIFF
--- a/iodbcadm/gtk/confirm.c
+++ b/iodbcadm/gtk/confirm.c
@@ -266,4 +266,6 @@ create_confirmw (HWND hwnd, LPCWSTR dsn, LPCWSTR text)
     free(_dsn);
   if (_text)
     free(_text);
+
+  return TRUE;
 }


### PR DESCRIPTION
Self-explanatory. The non-void function has a missing return value.
