### PR TITLE
fix build with gcc-15.0.1 too many arguments to function error

### DIFF
--- a/iodbc/connect.c
+++ b/iodbc/connect.c
@@ -2967,7 +2967,7 @@ SQLDriverConnect_Internal (
             prov[size/sizeof(SQLWCHAR)] = L'\0';
           }
 
-        retcode = dialproc (hwnd,	/* window or display handle */
+        retcode = ((SQLRETURN (*)(...))dialproc) (hwnd,	/* window or display handle */
           prov,		        /* input/output dsn buf */
           sizeof (prov) / (waMode == 'A' ? 1 : sizeof (SQLWCHAR)), /* buf size */
           &sqlstat,		/* error code */

--- a/iodbc/itrace.h
+++ b/iodbc/itrace.h
@@ -110,7 +110,7 @@ extern int ODBCSharedTraceFlag;
 \
 	if (!t_penv->thread_safe) MUTEX_LOCK (t_penv->drv_lock); \
 \
-	ret = proc plist; \
+	ret = ((SQLRETURN (*)(...))proc) plist; \
 	if (errHandle) ((GENV_t *)(errHandle))->rc = ret; \
 \
 	if (!t_penv->thread_safe) MUTEX_UNLOCK (t_penv->drv_lock); \


### PR DESCRIPTION
* GCC 15 considers it an error to pass arguments to a function pointer defined to take no arguments. This results in a 'too many arguments to function' error.

  At the problematic function pointer call sites, the pointer is cast to a variadic function pointer type (SQLRETURN (*)(...)) to avoid the error.

* see more details in http://errors.yoctoproject.org/Errors/Details/850317 ../../libiodbc-3.52.16/iodbc/hdbc.c: In function '_iodbcdm_SetConnectOption': ../../libiodbc-3.52.16/iodbc/hdbc.c:567:49: error: too many arguments to function 'hproc3'; expected 0, have 4
  567 |               CALL_DRIVER (hdbc, pdbc, retcode, hproc3,
      |                                                 ^~~~~~
  568 |                   (pdbc->dhdbc, fOption, vParam, 0));
      |                    ~~~~~~~~~~~
../../libiodbc-3.52.16/iodbc/itrace.h:113:15: note: in definition of macro 'CALL_DRIVER'
  113 |         ret = proc plist; \
      |               ^~~~
../../libiodbc-3.52.16/iodbc/hdbc.c:583:49: error: too many arguments to function 'hproc3'; expected 0, have 4
  583 |               CALL_DRIVER (hdbc, pdbc, retcode, hproc3,
      |                                                 ^~~~~~
  584 |                   (pdbc->dhdbc, fOption, vParam, SQL_NTS));
      |                    ~~~~~~~~~~~
../../libiodbc-3.52.16/iodbc/itrace.h:113:15: note: in definition of macro 'CALL_DRIVER'
  113 |         ret = proc plist; \
      |               ^~~~
../../libiodbc-3.52.16/iodbc/hdbc.c:597:45: error: too many arguments to function 'hproc2'; expected 0, have 3
  597 |           CALL_DRIVER (hdbc, pdbc, retcode, hproc2,
      |                                             ^~~~~~
  598 |               (pdbc->dhdbc, fOption, vParam));
      |                ~~~~~~~~~~~
....

../../libiodbc-3.52.16/iodbc/connect.c:2970:19: error: too many arguments to function 'dialproc'; expected 0, have 6
 2970 |         retcode = dialproc (hwnd,       /* window or display handle */
      |                   ^~~~~~~~  ~~~~