### PR TITLE
Fix a few minor build issues on musl

### DIFF
--- a/include/iodbc.h
+++ b/include/iodbc.h
@@ -98,6 +98,11 @@
 #if	!defined(WINDOWS) && !defined(WIN32_SYSTEM)
 #define _UNIX_
 
+#ifndef _POSIX_C_SOURCE
+/* POSIX.1-2008 is required for strdup() */
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/include/iodbc.h
+++ b/include/iodbc.h
@@ -101,6 +101,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/types.h>
 
 #define MEM_ALLOC(size)	(malloc((size_t)(size)))

--- a/iodbc/connect.c
+++ b/iodbc/connect.c
@@ -83,6 +83,7 @@
 #include <sqlucode.h>
 #include <iodbcext.h>
 #include <odbcinst.h>
+#include <time.h>
 
 #include "dlproc.h"
 


### PR DESCRIPTION
Attempting to build iODBC on a musl system, I hit a few "missing function" errors that turned out to be quick fixes. Two were missing includes, and one required a feature test macro to enable `strdup()`.
